### PR TITLE
logr v1.0.0-rc1 + `WithCallDepth`

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ import (
 )
 
 func main() {
-	logrusLog := logrus.New()
-	log := logrusr.NewLogger(logrusLog)
+    logrusLog := logrus.New()
+    log := logrusr.NewLogger(logrusLog)
 
-	log = log.WithName("MyName").WithValues("user", "you")
+    log = log.WithName("MyName").WithValues("user", "you")
     log.Info("Logr in action!", "the answer", 42)
 }
 ```

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@ import (
 )
 
 func main() {
-    var log logr.Logger
+	logrusLog := logrus.New()
+	log := logrusr.NewLogger(logrusLog)
 
-    log = logrusr.NewLogger(logrus.New())
-
+	log = log.WithName("MyName").WithValues("user", "you")
     log.Info("Logr in action!", "the answer", 42)
 }
 ```

--- a/example/main.go
+++ b/example/main.go
@@ -5,18 +5,13 @@ import (
 	"fmt"
 
 	"github.com/bombsimon/logrusr"
-	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 )
 
 func main() {
-	var (
-		log logr.Logger
-	)
-
 	logrusLog := logrus.New()
+	log := logrusr.NewLogger(logrusLog)
 
-	log = logrusr.NewLogger(logrusLog)
 	log = log.WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
 	log.V(0).Info("you should see this")
@@ -30,8 +25,8 @@ func main() {
 		"some_field":    "some_value",
 		"another_field": 42,
 	})
-
 	log = logrusr.NewLogger(entryLog)
+
 	log = log.WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
 	log.V(0).Info("you should see this")
@@ -39,6 +34,17 @@ func main() {
 	log.Error(nil, "uh oh", "trouble", true, "reasons", []float64{0.1, 0.11, 3.14})
 	log.Error(errors.New("caught error"), "goodbye", "code", -1)
 
+	fmt.Println("")
+
 	log = log.WithName("subpackage")
 	log.Info("hello from subpackage")
+	log.WithName("even_deeper").Info("hello even deeper")
+
+	fmt.Println("")
+
+	logrusLog = logrus.New()
+	logrusLog.SetLevel(logrus.TraceLevel)
+
+	log = logrusr.NewLogger(logrusLog)
+	log.V(2).Info("NOW you should see this")
 }

--- a/example/main.go
+++ b/example/main.go
@@ -10,7 +10,7 @@ import (
 
 func main() {
 	logrusLog := logrus.New()
-	log := logrusr.NewLogger(logrusLog)
+	log := logrusr.New(logrusLog)
 
 	log = log.WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
@@ -25,7 +25,7 @@ func main() {
 		"some_field":    "some_value",
 		"another_field": 42,
 	})
-	log = logrusr.NewLogger(entryLog)
+	log = logrusr.New(entryLog)
 
 	log = log.WithName("MyName").WithValues("user", "you")
 	log.Info("hello", "val1", 1, "val2", map[string]int{"k": 1})
@@ -45,6 +45,9 @@ func main() {
 	logrusLog = logrus.New()
 	logrusLog.SetLevel(logrus.TraceLevel)
 
-	log = logrusr.NewLogger(logrusLog)
+	log = logrusr.New(
+		logrusLog,
+		logrusr.WithReportCaller(),
+	).WithCallDepth(0)
 	log.V(2).Info("NOW you should see this")
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bombsimon/logrusr
 go 1.13
 
 require (
-	github.com/go-logr/logr v0.1.0
+	github.com/go-logr/logr v1.0.0-rc1
 	github.com/konsorten/go-windows-terminal-sequences v1.0.2 // indirect
 	github.com/kr/pretty v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v0.1.0 h1:M1Tv3VzNlEHg6uyACnRdtrploV2P7wZqH8BoQMtz0cg=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
+github.com/go-logr/logr v1.0.0-rc1 h1:+ul9F74rBkPajeP8m4o3o0tiglmzNFsPnuhYyBCQ0Sc=
+github.com/go-logr/logr v1.0.0-rc1/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1 h1:mweAR1A6xJ3oS2pRaGiHgQ4OO8tzTaLawm8vnODuwDk=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2 h1:DB17ag19krx9CFsz4o3enTrPXyIXCl+2iCXH/aMAp9s=

--- a/logrusr.go
+++ b/logrusr.go
@@ -101,10 +101,6 @@ func (l *logrusr) Enabled(level int) bool {
 // Info logs info messages if the logger is enabled, that is if the level on the
 // logger is set to logrus.InfoLevel or less.
 func (l *logrusr) Info(level int, msg string, keysAndValues ...interface{}) {
-	if !l.Enabled(level) {
-		return
-	}
-
 	if c := l.caller(); c != "" {
 		l.logger = l.logger.WithField("caller", c)
 	}

--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -231,7 +231,7 @@ func TestLogging(t *testing.T) {
 
 			// Send the created logger to the test case to invoke desired
 			// logging.
-			tc.logFunc(NewLoggerWithFormatter(logrusLogger, tc.formatter))
+			tc.logFunc(New(logrusLogger, WithFormatter(tc.formatter)))
 
 			if tc.assertions == nil {
 				assert.Equal(t, logWriter.Len(), 0)


### PR DESCRIPTION
* Update the implementation to work with logr v1.0.0-rc1
* Add options to `logrusr` constructor to only require one and avoid future breaking changes
* Add `WithCallDepth` and support to report caller
* Update examples and readme

Need some additional testing to ensure no race conditions, also need to update some tests. Since `logrusr` is already on v1.0.0 I also need to draft a v2.0.0 release since this contains breaking changes.