### PR TITLE
Map V-level logging to logrus named logging

### DIFF
--- a/logrusr.go
+++ b/logrusr.go
@@ -109,9 +109,15 @@ func (l *logrusr) Info(level int, msg string, keysAndValues ...interface{}) {
 		l.logger = l.logger.WithField("caller", c)
 	}
 
-	l.logger.
-		WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...)).
-		Info(msg)
+	log := l.logger.WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...))
+
+	if level <= 0 {
+		log.Info(msg)
+	} else if level == 1 {
+		log.Debug(msg)
+	} else {
+		log.Trace(msg)
+	}
 }
 
 // Error logs error messages. Since the log will be written with `Error` level

--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -87,9 +87,26 @@ func TestLogging(t *testing.T) {
 				return logrus.New()
 			},
 			logFunc: func(log logr.Logger) {
+				log.V(1).Info("hello, world")
 				log.V(2).Info("hello, world")
 			},
 			assertions: nil,
+		},
+		{
+			description: "V(1) logging with debug level set is shown",
+			logrusLogger: func() logrus.FieldLogger {
+				l := logrus.New()
+				l.SetLevel(logrus.TraceLevel)
+
+				return l
+			},
+			logFunc: func(log logr.Logger) {
+				log.V(1).Info("hello, world")
+			},
+			assertions: map[string]string{
+				"level": "debug",
+				"msg":   "hello, world",
+			},
 		},
 		{
 			description: "V(2) logging with trace level set is shown",
@@ -103,7 +120,7 @@ func TestLogging(t *testing.T) {
 				log.V(2).Info("hello, world")
 			},
 			assertions: map[string]string{
-				"level": "info",
+				"level": "trace",
 				"msg":   "hello, world",
 			},
 		},


### PR DESCRIPTION
After looking at the code for other logr implementations such as zapr
and zerologr it makes more sens that logrus also should try to map logr
V-level logging to named logging as close as possible.

* V0 is kept as severity Info
* V1 is logged as severity Debug
* V2 is logged as severity Trace

Closes #11 