### PR TITLE
Stop overwriting logger on struct when adding fields

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -42,7 +42,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Run tests
-        run: go test -v -covermode=count
+        run: go test -v -race -covermode=atomic
 
   coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
When adding caller, and for Info logs any other field, don't overwrite the
logger on the logrusr struct directly since we only want each individual  
message to contain this information.                                      
                                                                          
To make this easier, also always treat the logger internally as a         
`logrus.Entry` so we don't need to type cast when using it. This also     
makes us able to use the public duplication interface when duplicating    
the logger.                                                               

Add race detection flag when running tests