### PR TITLE
Simplify severity logging

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -49,5 +49,10 @@ func main() {
 		logrusLog,
 		logrusr.WithReportCaller(),
 	).WithCallDepth(0)
-	log.V(2).Info("NOW you should see this")
+
+	log.V(0).Info("you should see this as info")
+	log.V(1).Info("you should see this as debug")
+	log.V(2).Info("you should see this as trace")
+	log.V(1).V(1).Info("you should see this as trace")
+	log.V(10).Info("you should not see this")
 }

--- a/logrusr.go
+++ b/logrusr.go
@@ -103,15 +103,9 @@ func (l *logrusr) Info(level int, msg string, keysAndValues ...interface{}) {
 		log = log.WithField("caller", c)
 	}
 
-	log = log.WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...))
-
-	if level <= 0 {
-		log.Info(msg)
-	} else if level == 1 {
-		log.Debug(msg)
-	} else {
-		log.Trace(msg)
-	}
+	log.
+		WithFields(listToLogrusFields(l.defaultFormatter, keysAndValues...)).
+		Log(logrus.Level(level+logrusDiffToInfo), msg)
 }
 
 // Error logs error messages. Since the log will be written with `Error` level

--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -125,6 +125,38 @@ func TestLogging(t *testing.T) {
 			},
 		},
 		{
+			description: "negative V-logging truncates to info",
+			logrusLogger: func() logrus.FieldLogger {
+				l := logrus.New()
+				l.SetLevel(logrus.TraceLevel)
+
+				return l
+			},
+			logFunc: func(log logr.Logger) {
+				log.V(-10).Info("hello, world")
+			},
+			assertions: map[string]string{
+				"level": "info",
+				"msg":   "hello, world",
+			},
+		},
+		{
+			description: "addative V-logging, negatives ignored",
+			logrusLogger: func() logrus.FieldLogger {
+				l := logrus.New()
+				l.SetLevel(logrus.TraceLevel)
+
+				return l
+			},
+			logFunc: func(log logr.Logger) {
+				log.V(0).V(1).V(-20).V(1).Info("hello, world")
+			},
+			assertions: map[string]string{
+				"level": "trace",
+				"msg":   "hello, world",
+			},
+		},
+		{
 			description: "arguments are added while calling Info()",
 			logrusLogger: func() logrus.FieldLogger {
 				return logrus.New()


### PR DESCRIPTION
* Use entry.Log() instead of public named log levels to use proper
  logrus levels.
* Add tests for negative and addative V-levels
* Add more examples