### PR TITLE
Fix parallel invocation and also a couple typos per the spellchecker.

### DIFF
--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -129,7 +129,7 @@ func TestLogging(t *testing.T) {
 			},
 		},
 		{
-			description: "addative V-logging, negatives ignored",
+			description: "additive V-logging, negatives ignored",
 			logrusLevel: logrus.TraceLevel,
 			logFunc: func(log logr.Logger) {
 				log.V(0).V(1).V(-20).V(1).Info("hello, world")
@@ -163,7 +163,7 @@ func TestLogging(t *testing.T) {
 			},
 		},
 		{
-			description: "error logs have the approperate information",
+			description: "error logs have the appropriate information",
 			logFunc: func(log logr.Logger) {
 				log.Error(errors.New("this is error"), "error occurred")
 			},
@@ -272,6 +272,9 @@ func TestLogging(t *testing.T) {
 
 	for _, tc := range cases {
 		t.Run(tc.description, func(t *testing.T) {
+			tc := tc
+			t.Parallel()
+
 			// Use a buffer for our output.
 			logWriter := &bytes.Buffer{}
 
@@ -322,7 +325,7 @@ func TestLogging(t *testing.T) {
 				}
 
 				// Annotate regexp matches with the value starting with a tilde
-				// (~). The tilde will be dropped an used to compile a regexp to
+				// (~). The tilde will be dropped and used to compile a regexp to
 				// match the field.
 				if strings.HasPrefix(v, "~") {
 					assert.Regexp(t, regexp.MustCompile(v[1:]), field)


### PR DESCRIPTION
I noticed that the tests want to be run in parallel since the test function calls #Parallel.  However, this only allows the top-level function to run concurrently.  Since there are no other top-level functions in the test, there's no effect and the subtests run serially.

While you still want to call #Parallel at the beginning of the function (so you can write other test functions and have them run parallel too), you need to call it in the #Run closure as well.  Each subtest then runs in parallel.  As it turns out, the tests are so fast that it makes no difference anyway, but I thought you should see the way to get the subtests running as well.  Honestly, dropping concurrency is probably simpler, so feel free to do whatever with this PR.

Some refs:

https://gist.github.com/posener/92a55c4cd441fc5e5e85f27bca008721
https://github.com/moricho/tparallel

(Forgive the spelling corrections, my IDE makes the suggestions and I just accepted them.)