### PR TITLE
Remove one frame from the default call depth

### DIFF
--- a/example/main.go
+++ b/example/main.go
@@ -48,7 +48,7 @@ func main() {
 	log = logrusr.New(
 		logrusLog,
 		logrusr.WithReportCaller(),
-	).WithCallDepth(0)
+	)
 
 	log.V(0).Info("you should see this as info")
 	log.V(1).Info("you should see this as debug")

--- a/logrusr.go
+++ b/logrusr.go
@@ -77,7 +77,13 @@ func New(l logrus.FieldLogger, opts ...Option) logr.Logger {
 
 // Init receives optional information about the library.
 func (l *logrusr) Init(ri logr.RuntimeInfo) {
-	l.depth = ri.CallDepth
+	// By default `CallDepth` is set to 1 which means one of the frames is
+	// skipped by default. This was originally missed in this library making the
+	// default behavior and `WithCallDepth(0)` behave differently.
+	// To be backwards compatible without affecting anyone manually setting the
+	// call depth we reduce 1 from the default depth instead of not adding it.
+	// See https://github.com/bombsimon/logrusr/issues/19 for more info.
+	l.depth = ri.CallDepth - 1
 }
 
 // Enabled tests whether this Logger is enabled. It will return true if the


### PR DESCRIPTION
Ensure call depth starts at 0 instead of 1 to properly remove correct number of frames when fetching the caller. This changes makes the default behavior and `WithCallDepth(0)` behave the same, meaning any manually specified call depths will also be the same and thus backwards compatible.

Fixes #19