### PR TITLE
Adapt `FormatFunc` return type to the expected `logrus.Fields` type

### DIFF
--- a/logrusr.go
+++ b/logrusr.go
@@ -19,7 +19,7 @@ const logrusDiffToInfo = 4
 
 // FormatFunc is the function to format log values with for non primitive data.
 // By default, this is empty and the data will be JSON marshaled.
-type FormatFunc func(interface{}) string
+type FormatFunc func(interface{}) interface{}
 
 // Option is options to give when construction a logrusr logger.
 type Option func(l *logrusr)
@@ -150,7 +150,7 @@ func (l *logrusr) WithName(name string) logr.LogSink {
 }
 
 // listToLogrusFields converts a list of arbitrary length to key/value paris.
-func listToLogrusFields(formatter func(interface{}) string, keysAndValues ...interface{}) logrus.Fields {
+func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logrus.Fields {
 	f := make(logrus.Fields)
 
 	// Skip all fields if it's not an even length list.

--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -22,7 +22,7 @@ func TestLogging(t *testing.T) {
 		description  string
 		logrusLevel  logrus.Level
 		logFunc      func(log logr.Logger)
-		formatter    func(interface{}) string
+		formatter    FormatFunc
 		reportCaller bool
 		defaultName  []string
 		assertions   map[string]string
@@ -212,7 +212,7 @@ func TestLogging(t *testing.T) {
 			logFunc: func(log logr.Logger) {
 				log.Info("hello, world", "list", []int{1, 2, 3})
 			},
-			formatter: func(val interface{}) string {
+			formatter: func(val interface{}) interface{} {
 				return fmt.Sprintf("%v", val)
 			},
 			assertions: map[string]string{


### PR DESCRIPTION
Modifies `listToLogrusFields` to use `FormatFunc`, and adapt the later return type to the expected logrus.Fields type

Logrus:
```go
// Fields type, used to pass to `WithFields`.
type Fields map[string]interface{}
```
https://github.com/sirupsen/logrus/blob/f8bf7650dccb756cea26edaf9217aab85500fe07/logrus.go#LL10