### PR TITLE
This commit change the way to mapping the default `logging level`:

### DIFF
--- a/logrusr.go
+++ b/logrusr.go
@@ -73,7 +73,7 @@ func New(l logrus.FieldLogger, opts ...Option) logr.Logger {
 		o(logger)
 	}
 
-	return logr.New(logger)
+	return logr.New(logger).V(logrusDiffToInfo)
 }
 
 // Init receives optional information about the library.
@@ -99,7 +99,7 @@ func (l *logrusr) Enabled(level int) bool {
 	// logrus.InfoLevel has value 4 so if the level on the logger is set to 0 we
 	// should only be seen as enabled if the logrus logger has a severity of
 	// info or higher.
-	return l.logger.Logger.IsLevelEnabled(logrus.Level(level + logrusDiffToInfo))
+	return l.logger.Logger.IsLevelEnabled(logrus.Level(level))
 }
 
 // Info logs info messages if the logger is enabled, that is if the level on the
@@ -112,7 +112,7 @@ func (l *logrusr) Info(level int, msg string, keysAndValues ...interface{}) {
 
 	log.
 		WithFields(listToLogrusFields(l.formatter, keysAndValues...)).
-		Log(logrus.Level(level+logrusDiffToInfo), msg)
+		Log(logrus.Level(level), msg)
 }
 
 // Error logs error messages. Since the log will be written with `Error` level


### PR DESCRIPTION
By default, the newly created logging by `logrusr ` is `Info Level` corresponding to backend, to get this mapping work:
- In the previous way, the mapping is implemented by Enabled and Info functions which is hard to understand and debug.
- Now, I use the standard `V()` to obtain this.