### PR TITLE
Fix error value logging

### DIFF
--- a/logrusr.go
+++ b/logrusr.go
@@ -186,7 +186,7 @@ func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logr
 		case int, int8, int16, int32, int64,
 			uint, uint8, uint16, uint32, uint64,
 			float32, float64, complex64, complex128,
-			string, bool:
+			string, bool, error:
 			f[s] = vVal
 
 		case []byte:

--- a/logrusr_test.go
+++ b/logrusr_test.go
@@ -49,6 +49,19 @@ func TestLogging(t *testing.T) {
 			},
 		},
 		{
+			description: "log errors",
+			logFunc: func(log logr.Logger) {
+				var empty error
+				log.Info("hello, world", "error", errors.New("test"), "empty", empty)
+			},
+			assertions: map[string]string{
+				"level": "info",
+				"msg":   "hello, world",
+				"error": "test",
+				"empty": "null",
+			},
+		},
+		{
 			description: "set name once",
 			logFunc: func(log logr.Logger) {
 				log.WithName("main").Info("hello, world")


### PR DESCRIPTION
I was implementing some changes for slog compatibility and noticed that errors where not shown correctly.
Turns out that errors are only correctly printed when they are passed in `logr.Logger.Error` as first argument.
This is because the error passes through the switch in `listToLogrusFields` and lands in the default case.
In most cases this leads to the error being JSON marshaled which rarely yields usable results.

Address this edge case by adding `error` to the list of known types that are directly passed into fields.
