### PR TITLE
Update logr and provide basic slog interop

### DIFF
--- a/example_slog_test.go
+++ b/example_slog_test.go
@@ -17,11 +17,15 @@ func ExampleNew() {
 	l := logrus.New()
 	l.Formatter.(*logrus.TextFormatter).DisableTimestamp = true
 	l.Out = os.Stdout
-	log := slog.New(logr.ToSlogHandler(logrusr.New(l)))
-	log = log.With("number", slog.IntValue(123))
+
+	log := slog.
+		New(logr.ToSlogHandler(logrusr.New(l))).
+		With("number", slog.IntValue(123))
+
 	log.Debug("do not print this!")
 	log.Info("print this please", slog.String("key", "value"), slog.Group("test", slog.Group("nested", "foo", "bar")))
 	log.Error("oh no", "error", errors.New("some error"))
+
 	// Output:
 	// level=info msg="print this please" key=value number=123 test.nested.foo=bar
 	// level=error msg="oh no" error="some error" number=123

--- a/example_slog_test.go
+++ b/example_slog_test.go
@@ -1,0 +1,28 @@
+//go:build go1.21
+// +build go1.21
+
+package logrusr_test
+
+import (
+	"errors"
+	"log/slog"
+	"os"
+
+	"github.com/bombsimon/logrusr/v4"
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+func ExampleNew() {
+	l := logrus.New()
+	l.Formatter.(*logrus.TextFormatter).DisableTimestamp = true
+	l.Out = os.Stdout
+	log := slog.New(logr.ToSlogHandler(logrusr.New(l)))
+	log = log.With("number", slog.IntValue(123))
+	log.Debug("do not print this!")
+	log.Info("print this please", slog.String("key", "value"), slog.Group("test", slog.Group("nested", "foo", "bar")))
+	log.Error("oh no", "error", errors.New("some error"))
+	// Output:
+	// level=info msg="print this please" key=value number=123 test.nested.foo=bar
+	// level=error msg="oh no" error="some error" number=123
+}

--- a/go.mod
+++ b/go.mod
@@ -1,9 +1,9 @@
 module github.com/bombsimon/logrusr/v4
 
-go 1.17
+go 1.18
 
 require (
-	github.com/go-logr/logr v1.2.3
+	github.com/go-logr/logr v1.4.1
 	github.com/sirupsen/logrus v1.9.0
 	github.com/stretchr/testify v1.8.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
-github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.4.1 h1:pKouT5E8xu9zeFC39JXRDukb6JFQPXM5p5I91188VAQ=
+github.com/go-logr/logr v1.4.1/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=

--- a/logrusr.go
+++ b/logrusr.go
@@ -1,7 +1,6 @@
 package logrusr
 
 import (
-	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -128,8 +127,8 @@ func (l *logrusr) Error(err error, msg string, keysAndValues ...interface{}) {
 	}
 
 	log.
-		WithFields(listToLogrusFields(l.formatter, keysAndValues...)).
 		WithError(err).
+		WithFields(listToLogrusFields(l.formatter, keysAndValues...)).
 		Error(msg)
 }
 
@@ -157,52 +156,6 @@ func (l *logrusr) WithName(name string) logr.LogSink {
 	)
 
 	return newLogger
-}
-
-// listToLogrusFields converts a list of arbitrary length to key/value paris.
-func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logrus.Fields {
-	f := make(logrus.Fields)
-
-	// Skip all fields if it's not an even length list.
-	if len(keysAndValues)%2 != 0 {
-		return f
-	}
-
-	for i := 0; i < len(keysAndValues); i += 2 {
-		k, v := keysAndValues[i], keysAndValues[i+1]
-
-		s, ok := k.(string)
-		if !ok {
-			continue
-		}
-
-		if v, ok := v.(logr.Marshaler); ok {
-			f[s] = v.MarshalLog()
-			continue
-		}
-
-		// Try to avoid marshaling known types.
-		switch vVal := v.(type) {
-		case int, int8, int16, int32, int64,
-			uint, uint8, uint16, uint32, uint64,
-			float32, float64, complex64, complex128,
-			string, bool, error:
-			f[s] = vVal
-
-		case []byte:
-			f[s] = string(vVal)
-
-		default:
-			if formatter != nil {
-				f[s] = formatter(v)
-			} else {
-				j, _ := json.Marshal(vVal)
-				f[s] = string(j)
-			}
-		}
-	}
-
-	return f
 }
 
 // copyLogger copies the logger creating a new slice of the name but preserving

--- a/logrusr.go
+++ b/logrusr.go
@@ -1,6 +1,7 @@
 package logrusr
 
 import (
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -199,4 +200,17 @@ func (l *logrusr) caller() string {
 	}
 
 	return fmt.Sprintf("%s:%d", filepath.Base(file), line)
+}
+
+// formatterOrMarshal will format the value with the format function if any,
+// otherwise it will use `json.Marshal` and return the marshalled value as a
+// string.
+func formatterOrMarshal(value any, formatter FormatFunc) interface{} {
+	if formatter != nil {
+		return formatter(value)
+	}
+
+	j, _ := json.Marshal(value)
+
+	return string(j)
 }

--- a/logrusr_noslog.go
+++ b/logrusr_noslog.go
@@ -4,8 +4,6 @@
 package logrusr
 
 import (
-	"encoding/json"
-
 	"github.com/go-logr/logr"
 	"github.com/sirupsen/logrus"
 )
@@ -44,12 +42,7 @@ func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logr
 			f[s] = string(vVal)
 
 		default:
-			if formatter != nil {
-				f[s] = formatter(v)
-			} else {
-				j, _ := json.Marshal(vVal)
-				f[s] = string(j)
-			}
+			f[s] = formatterOrMarshal(v, formatter)
 		}
 	}
 

--- a/logrusr_noslog.go
+++ b/logrusr_noslog.go
@@ -1,0 +1,57 @@
+//go:build !go1.21
+// +build !go1.21
+
+package logrusr
+
+import (
+	"encoding/json"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+// listToLogrusFields converts a list of arbitrary length to key/value paris.
+func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logrus.Fields {
+	f := make(logrus.Fields)
+
+	// Skip all fields if it's not an even length list.
+	if len(keysAndValues)%2 != 0 {
+		return f
+	}
+
+	for i := 0; i < len(keysAndValues); i += 2 {
+		k, v := keysAndValues[i], keysAndValues[i+1]
+
+		s, ok := k.(string)
+		if !ok {
+			continue
+		}
+
+		if v, ok := v.(logr.Marshaler); ok {
+			f[s] = v.MarshalLog()
+			continue
+		}
+
+		// Try to avoid marshaling known types.
+		switch vVal := v.(type) {
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64,
+			float32, float64, complex64, complex128,
+			string, bool, error:
+			f[s] = vVal
+
+		case []byte:
+			f[s] = string(vVal)
+
+		default:
+			if formatter != nil {
+				f[s] = formatter(v)
+			} else {
+				j, _ := json.Marshal(vVal)
+				f[s] = string(j)
+			}
+		}
+	}
+
+	return f
+}

--- a/logrusr_slog.go
+++ b/logrusr_slog.go
@@ -4,7 +4,6 @@
 package logrusr
 
 import (
-	"encoding/json"
 	"log/slog"
 
 	"github.com/go-logr/logr"
@@ -49,12 +48,7 @@ func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logr
 			f[s] = string(vVal)
 
 		default:
-			if formatter != nil {
-				f[s] = formatter(v)
-			} else {
-				j, _ := json.Marshal(v)
-				f[s] = string(j)
-			}
+			f[s] = formatterOrMarshal(v, formatter)
 		}
 	}
 
@@ -97,22 +91,22 @@ func formatSlog(fields logrus.Fields, formatter FormatFunc, attr slog.Attr) {
 			for _, attr := range attrs {
 				formatSlog(fields, formatter, attr)
 			}
+
 			return
 		}
+
 		if len(attrs) == 0 {
 			return
 		}
+
 		value := make(logrus.Fields)
 		for _, attr := range attrs {
 			formatSlog(value, formatter, attr)
 		}
+
 		fields[attr.Key] = value
 
 	default:
-		if formatter != nil {
-			fields[attr.Key] = formatter(attr.Value.Any())
-		}
-		v, _ := json.Marshal(attr.Value.Any())
-		fields[attr.Key] = string(v)
+		fields[attr.Key] = formatterOrMarshal(attr.Value.Any(), formatter)
 	}
 }

--- a/logrusr_slog.go
+++ b/logrusr_slog.go
@@ -1,0 +1,118 @@
+//go:build go1.21
+// +build go1.21
+
+package logrusr
+
+import (
+	"encoding/json"
+	"log/slog"
+
+	"github.com/go-logr/logr"
+	"github.com/sirupsen/logrus"
+)
+
+// listToLogrusFields converts a list of arbitrary length to key/value paris.
+func listToLogrusFields(formatter FormatFunc, keysAndValues ...interface{}) logrus.Fields {
+	f := make(logrus.Fields)
+
+	// Skip all fields if it's not an even length list.
+	if len(keysAndValues)%2 != 0 {
+		return f
+	}
+
+	for i := 0; i < len(keysAndValues); i += 2 {
+		k, v := keysAndValues[i], keysAndValues[i+1]
+
+		s, ok := k.(string)
+		if !ok {
+			continue
+		}
+
+		// Try to avoid marshaling known types.
+		switch vVal := v.(type) {
+		case logr.Marshaler:
+			f[s] = vVal.MarshalLog()
+
+		case slog.LogValuer:
+			f[s] = slog.AnyValue(vVal).Resolve()
+
+		case slog.Value:
+			formatSlog(f, formatter, slog.Attr{Key: s, Value: vVal})
+
+		case int, int8, int16, int32, int64,
+			uint, uint8, uint16, uint32, uint64,
+			float32, float64, complex64, complex128,
+			string, bool, error:
+			f[s] = vVal
+
+		case []byte:
+			f[s] = string(vVal)
+
+		default:
+			if formatter != nil {
+				f[s] = formatter(v)
+			} else {
+				j, _ := json.Marshal(v)
+				f[s] = string(j)
+			}
+		}
+	}
+
+	return f
+}
+
+func formatSlog(fields logrus.Fields, formatter FormatFunc, attr slog.Attr) {
+	switch attr.Value.Kind() {
+	case slog.KindString:
+		fields[attr.Key] = attr.Value.String()
+
+	case slog.KindLogValuer:
+		formatSlog(fields, formatter, slog.Attr{
+			Key:   attr.Key,
+			Value: attr.Value.Resolve(),
+		})
+
+	case slog.KindInt64:
+		fields[attr.Key] = attr.Value.Int64()
+
+	case slog.KindUint64:
+		fields[attr.Key] = attr.Value.Uint64()
+
+	case slog.KindFloat64:
+		fields[attr.Key] = attr.Value.Float64()
+
+	case slog.KindBool:
+		fields[attr.Key] = attr.Value.Bool()
+
+	case slog.KindDuration:
+		fields[attr.Key] = attr.Value.Duration()
+
+	case slog.KindTime:
+		fields[attr.Key] = attr.Value.Time()
+
+	case slog.KindGroup:
+		attrs := attr.Value.Group()
+		if attr.Key == "" {
+			// Inline group
+			for _, attr := range attrs {
+				formatSlog(fields, formatter, attr)
+			}
+			return
+		}
+		if len(attrs) == 0 {
+			return
+		}
+		value := make(logrus.Fields)
+		for _, attr := range attrs {
+			formatSlog(value, formatter, attr)
+		}
+		fields[attr.Key] = value
+
+	default:
+		if formatter != nil {
+			fields[attr.Key] = formatter(attr.Value.Any())
+		}
+		v, _ := json.Marshal(attr.Value.Any())
+		fields[attr.Key] = string(v)
+	}
+}


### PR DESCRIPTION
Update logr dependency to 1.4.1.

It is [recommended](https://github.com/go-logr/logr?tab=readme-ov-file#slog-interoperability) that log sink implementations are compatible with slog.
This PR makes the `ToSlogHandler` direction work by adding support for slog values.

There is one major caveat: errors passed to `slog.Error` must have the key `error` otherwise the two (2) error fields will be displayed. One is the `WithError` field that is always added and another is the actual error that will be printed.
I moved the `WithError` call before `WithFields` to ensure that the error at least *can* be overwritten.

I think this problem can only be solved by implementing a slog handler that knows in what context it's OK to log nil errors and when they can be omitted.
